### PR TITLE
Added logging and schema registry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile "org.apache.avro:avro-maven-plugin:${avroVersion}"
     compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     compile 'org.springframework.boot:spring-boot-starter-web'
+    compile 'org.springframework.cloud:spring-cloud-stream-schema'
     compile 'org.springframework.cloud:spring-cloud-starter-stream-rabbit'
 
     testCompile "org.springframework.boot:spring-boot-starter-test"

--- a/src/main/avro/course_install.avsc
+++ b/src/main/avro/course_install.avsc
@@ -10,7 +10,7 @@
              "name": "Course",
              "fields": [
                 {"name": "uuid", "type": "string"},
-                {"name": "name", "type": "string"},
+                {"name": "name", "type": "string", "aliases": ["courseName"]},
                 {"name": "knownLanguage", "type": "string"},
                 {"name": "targetLanguage", "type": "string"},
                 {"name": "product", "type": "string"}
@@ -24,7 +24,7 @@
                 "type": "record",
                 "name": "Unit",
                 "fields": [
-                    {"name": "id", "type": "int"},
+                    {"name": "id", "type": "int", "default": 0},
                     {"name": "uuid", "type": "string"},
                     {"name": "name", "type": "string"},
                     {"name": "maxScore", "type": "int"},

--- a/src/main/groovy/com/vherasymenko/avro/Application.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/Application.groovy
@@ -15,16 +15,18 @@ import com.vherasymenko.avro.encoder.core.binary.AvroBinaryEncoderPort
 import com.vherasymenko.avro.encoder.core.binary.AvroBinaryEncoderService
 import com.vherasymenko.avro.encoder.core.json.AvroJsonEncoderService
 import com.vherasymenko.avro.encoder.core.json.AvroJsonEncoderPort
-import com.vherasymenko.avro.encoder.core.CourseInstallPort
-import com.vherasymenko.avro.encoder.core.CourseInstallService
-import com.vherasymenko.avro.encoder.core.LessonStatusPort
-import com.vherasymenko.avro.encoder.core.LessonStatusService
+import com.vherasymenko.avro.encoder.core.CourseInstallEncoderPort
+import com.vherasymenko.avro.encoder.core.CourseInstallEncoderService
+import com.vherasymenko.avro.encoder.core.LessonStatusEncoderPort
+import com.vherasymenko.avro.encoder.core.LessonStatusEncoderService
 import com.vherasymenko.avro.encoder.outbound.MessageProducer
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.cloud.stream.schema.client.ConfluentSchemaRegistryClient
+import org.springframework.cloud.stream.schema.client.SchemaRegistryClient
 import org.springframework.context.annotation.Bean
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.web.client.RestOperations
@@ -39,6 +41,11 @@ class Application {
 
     static void main( String[] args ) {
         SpringApplication.run( Application, args )
+    }
+
+    @Bean
+    SchemaRegistryClient registryClient() {
+        new ConfluentSchemaRegistryClient()
     }
 
     @Bean
@@ -68,13 +75,13 @@ class Application {
     }
 
     @Bean
-    CourseInstallPort courseInstallEncoder( MessageProducer producer, AvroJsonEncoderPort encoder ) {
-        new CourseInstallService( producer, encoder )
+    CourseInstallEncoderPort courseInstallEncoder( MessageProducer producer, AvroJsonEncoderPort encoder, SchemaRegistryClient registryClient ) {
+        new CourseInstallEncoderService( producer, encoder, registryClient )
     }
 
     @Bean
-    LessonStatusPort lessonStatusEncoder( MessageProducer producer, AvroBinaryEncoderPort encoder ) {
-        new LessonStatusService( producer, encoder )
+    LessonStatusEncoderPort lessonStatusEncoder(MessageProducer producer, AvroBinaryEncoderPort encoder ) {
+        new LessonStatusEncoderService( producer, encoder )
     }
 
     // Decoder
@@ -90,8 +97,8 @@ class Application {
     }
 
     @Bean
-     CourseInstallDecoderPort courseInstallDecoder( AvroJsonDecoderPort decoder ) {
-        new CourseInstallDecoderService( decoder )
+     CourseInstallDecoderPort courseInstallDecoder( AvroJsonDecoderPort decoder, SchemaRegistryClient registryClient ) {
+        new CourseInstallDecoderService( decoder, registryClient )
     }
 
     @Bean

--- a/src/main/groovy/com/vherasymenko/avro/Application.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/Application.groovy
@@ -80,8 +80,8 @@ class Application {
     }
 
     @Bean
-    LessonStatusEncoderPort lessonStatusEncoder(MessageProducer producer, AvroBinaryEncoderPort encoder ) {
-        new LessonStatusEncoderService( producer, encoder )
+    LessonStatusEncoderPort lessonStatusEncoder( MessageProducer producer, AvroBinaryEncoderPort encoder, SchemaRegistryClient registryClient ) {
+        new LessonStatusEncoderService( producer, encoder, registryClient )
     }
 
     // Decoder
@@ -102,8 +102,8 @@ class Application {
     }
 
     @Bean
-    LessonStatusDecoderPort lessonStatusDecoder( AvroBinaryDecoderPort decoder ) {
-        new LessonStatusDecoderService( decoder )
+    LessonStatusDecoderPort lessonStatusDecoder( AvroBinaryDecoderPort decoder, SchemaRegistryClient registryClient ) {
+        new LessonStatusDecoderService( decoder, registryClient )
     }
 
     @Bean

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/CourseInstallDecoderPort.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/CourseInstallDecoderPort.groovy
@@ -5,5 +5,5 @@ package com.vherasymenko.avro.decoder.core
  */
 interface CourseInstallDecoderPort {
 
-    void decodeCourseInstallEvent( String event )
+    void decodeCourseInstallEvent( String event, int schemaId )
 }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/CourseInstallDecoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/CourseInstallDecoderService.groovy
@@ -2,12 +2,14 @@ package com.vherasymenko.avro.decoder.core
 
 import com.vherasymenko.avro.decoder.core.json.AvroJsonDecoderPort
 import event.course_install.CourseInstall
+import groovy.util.logging.Slf4j
+import org.apache.avro.Schema
 
 /**
  * Decoder for the course install document.
  */
+@Slf4j
 class CourseInstallDecoderService implements CourseInstallDecoderPort {
-
 
     private final AvroJsonDecoderPort decoder
 
@@ -18,6 +20,9 @@ class CourseInstallDecoderService implements CourseInstallDecoderPort {
     @Override
     void decodeCourseInstallEvent( String event ) {
         def schema = CourseInstall.classSchema
-        decoder.decodeEvent( schema, event )
+        def newSchema = new Schema.Parser().parse( new File( 'src/main/resources/avro/course_install_2.avsc' ) )
+        log.info( 'The avro schema for event decoding : ' + newSchema.toString( true ) )
+
+        decoder.decodeEvent( schema, newSchema, event )
     }
 }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/LessonStatusDecoderPort.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/LessonStatusDecoderPort.groovy
@@ -5,5 +5,5 @@ package com.vherasymenko.avro.decoder.core
  */
 interface LessonStatusDecoderPort {
 
-    void decodeLessonInstallEvent( byte[] event )
+    void decodeLessonInstallEvent( byte[] event, int schemaId )
 }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/LessonStatusDecoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/LessonStatusDecoderService.groovy
@@ -1,11 +1,13 @@
 package com.vherasymenko.avro.decoder.core
 
 import com.vherasymenko.avro.decoder.core.binary.AvroBinaryDecoderPort
+import groovy.util.logging.Slf4j
 import org.apache.avro.Schema
 
 /**
  * Decoder for the lesson status document.
  */
+@Slf4j
 class LessonStatusDecoderService implements LessonStatusDecoderPort {
 
     private final AvroBinaryDecoderPort decoder
@@ -19,6 +21,8 @@ class LessonStatusDecoderService implements LessonStatusDecoderPort {
         def parser = new Schema.Parser()
         parser.parse( new File( 'src/main/avro/lessonStatusItem.avsc' ) )
         def schema = parser.parse( new File( 'src/main/avro/lesson_status.avsc' ) )
+        log.info( 'The avro schema for event decoding : ' + schema.toString( true ) )
+
         decoder.decodeEvent( schema, event )
     }
 }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/LessonStatusDecoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/LessonStatusDecoderService.groovy
@@ -3,6 +3,7 @@ package com.vherasymenko.avro.decoder.core
 import com.vherasymenko.avro.decoder.core.binary.AvroBinaryDecoderPort
 import groovy.util.logging.Slf4j
 import org.apache.avro.Schema
+import org.springframework.cloud.stream.schema.client.SchemaRegistryClient
 
 /**
  * Decoder for the lesson status document.
@@ -12,15 +13,16 @@ class LessonStatusDecoderService implements LessonStatusDecoderPort {
 
     private final AvroBinaryDecoderPort decoder
 
-    LessonStatusDecoderService( AvroBinaryDecoderPort aDecoder ) {
+    private final SchemaRegistryClient registryClient
+
+    LessonStatusDecoderService( AvroBinaryDecoderPort aDecoder, SchemaRegistryClient aRegistryClient ) {
         decoder = aDecoder
+        registryClient = aRegistryClient
     }
 
     @Override
-    void decodeLessonInstallEvent( byte[] event ) {
-        def parser = new Schema.Parser()
-        parser.parse( new File( 'src/main/avro/lessonStatusItem.avsc' ) )
-        def schema = parser.parse( new File( 'src/main/avro/lesson_status.avsc' ) )
+    void decodeLessonInstallEvent( byte[] event, int schemaId ) {
+        def schema = new Schema.Parser().parse( registryClient.fetch( schemaId ) )
         log.info( 'The avro schema for event decoding : ' + schema.toString( true ) )
 
         decoder.decodeEvent( schema, event )

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/MessageRouter.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/MessageRouter.groovy
@@ -11,8 +11,14 @@ import org.springframework.messaging.Message
 @Slf4j
 class MessageRouter implements MessageRouterPort {
 
+    /**
+     * Handles course install document decoding.
+     */
     private final CourseInstallDecoderPort courseInstallDecoder
 
+    /**
+     * Handles lesson install document decoding.
+     */
     private final LessonStatusDecoderPort lessonStatusDecoder
 
     MessageRouter( CourseInstallDecoderPort aCourseInstallDecoder, LessonStatusDecoderPort aLessonStatusDecoder ) {
@@ -23,11 +29,12 @@ class MessageRouter implements MessageRouterPort {
     @Override
     void routeEvent( Message eventMessage ) {
         def eventContentType = eventMessage.headers.get( MessageHeaders.CONTENT_TYPE )
+        def schemaId = eventMessage.headers.get( MessageHeaders.SCHEMA_ID ) as int
         def eventPayload = eventMessage.payload
 
         if ( eventContentType == AvroConstants.COURSE_INSTALL_CHANNEL ) {
             log.info( 'The message is sent to the ' + AvroConstants.COURSE_INSTALL_CHANNEL )
-            courseInstallDecoder.decodeCourseInstallEvent( eventPayload as String )
+            courseInstallDecoder.decodeCourseInstallEvent( eventPayload as String, schemaId )
         }
         else if ( eventContentType == AvroConstants.LESSON_STATUS_CHANNEL ) {
             log.info( 'The message is sent to the ' + AvroConstants.LESSON_STATUS_CHANNEL )

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/MessageRouter.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/MessageRouter.groovy
@@ -2,11 +2,13 @@ package com.vherasymenko.avro.decoder.core
 
 import com.vherasymenko.avro.schared.AvroConstants
 import com.vherasymenko.avro.schared.MessageHeaders
+import groovy.util.logging.Slf4j
 import org.springframework.messaging.Message
 
 /**
  * Routes messages from messaging system to different decoders.
  */
+@Slf4j
 class MessageRouter implements MessageRouterPort {
 
     private final CourseInstallDecoderPort courseInstallDecoder
@@ -24,9 +26,11 @@ class MessageRouter implements MessageRouterPort {
         def eventPayload = eventMessage.payload
 
         if ( eventContentType == AvroConstants.COURSE_INSTALL_CHANNEL ) {
+            log.info( 'The message is sent to the ' + AvroConstants.COURSE_INSTALL_CHANNEL )
             courseInstallDecoder.decodeCourseInstallEvent( eventPayload as String )
         }
         else if ( eventContentType == AvroConstants.LESSON_STATUS_CHANNEL ) {
+            log.info( 'The message is sent to the ' + AvroConstants.LESSON_STATUS_CHANNEL )
             lessonStatusDecoder.decodeLessonInstallEvent( eventPayload as byte[] )
         }
     }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/MessageRouter.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/MessageRouter.groovy
@@ -38,7 +38,7 @@ class MessageRouter implements MessageRouterPort {
         }
         else if ( eventContentType == AvroConstants.LESSON_STATUS_CHANNEL ) {
             log.info( 'The message is sent to the ' + AvroConstants.LESSON_STATUS_CHANNEL )
-            lessonStatusDecoder.decodeLessonInstallEvent( eventPayload as byte[] )
+            lessonStatusDecoder.decodeLessonInstallEvent( eventPayload as byte[], schemaId )
         }
     }
 }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/binary/AvroBinaryDecoderPort.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/binary/AvroBinaryDecoderPort.groovy
@@ -7,5 +7,5 @@ import org.apache.avro.Schema
  */
 interface AvroBinaryDecoderPort {
 
-    void decodeEvent(Schema schema, byte[] event )
+    void decodeEvent( Schema schema, byte[] event )
 }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/binary/AvroBinaryDecoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/binary/AvroBinaryDecoderService.groovy
@@ -17,7 +17,8 @@ class AvroBinaryDecoderService implements AvroBinaryDecoderPort {
     void decodeEvent( Schema schema, byte[] event ) {
         def decoder = new DecoderFactory().binaryDecoder( event, null )
         DatumReader<GenericRecord> reader = new GenericDatumReader<>( schema )
-        def document = reader.read( null, decoder )
+        def reuse = null // if reuse is provided, it will be reinitialized to the given input stream
+        def document = reader.read( reuse, decoder )
         log.info( 'Decoded document with binary avro decoder: ' + document )
     }
 }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/binary/AvroBinaryDecoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/binary/AvroBinaryDecoderService.groovy
@@ -1,5 +1,6 @@
 package com.vherasymenko.avro.decoder.core.binary
 
+import groovy.util.logging.Slf4j
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericDatumReader
 import org.apache.avro.generic.GenericRecord
@@ -9,6 +10,7 @@ import org.apache.avro.io.DecoderFactory
 /**
  * The avro binary decoder.
  */
+@Slf4j
 class AvroBinaryDecoderService implements AvroBinaryDecoderPort {
 
     @Override
@@ -16,7 +18,6 @@ class AvroBinaryDecoderService implements AvroBinaryDecoderPort {
         def decoder = new DecoderFactory().binaryDecoder( event, null )
         DatumReader<GenericRecord> reader = new GenericDatumReader<>( schema )
         def document = reader.read( null, decoder )
-        println( 'Decoded document: ' + document )
-        document
+        log.info( 'Decoded document with binary avro decoder: ' + document )
     }
 }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/json/AvroJsonDecoderPort.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/json/AvroJsonDecoderPort.groovy
@@ -7,5 +7,5 @@ import org.apache.avro.Schema
  */
 interface AvroJsonDecoderPort {
 
-    void decodeEvent( Schema schema, String event )
+    void decodeEvent( Schema schema, Schema newSchema, String event )
 }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/core/json/AvroJsonDecoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/core/json/AvroJsonDecoderService.groovy
@@ -1,5 +1,6 @@
 package com.vherasymenko.avro.decoder.core.json
 
+import groovy.util.logging.Slf4j
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericDatumReader
 import org.apache.avro.generic.GenericRecord
@@ -9,14 +10,14 @@ import org.apache.avro.io.DecoderFactory
 /**
  * The avro json decoder.
  */
+@Slf4j
 class AvroJsonDecoderService implements AvroJsonDecoderPort {
 
     @Override
-    void decodeEvent( Schema schema, String event ) {
+    void decodeEvent( Schema schema, Schema newSchema, String event ) {
         def decoder = new DecoderFactory().jsonDecoder( schema, event )
-        DatumReader<GenericRecord> reader = new GenericDatumReader<>( schema )
+        DatumReader<GenericRecord> reader = new GenericDatumReader<>( schema, newSchema )
         def document = reader.read( null, decoder )
-        println( 'Decoded document: ' + document )
-        document
+        log.info( 'Decoded document with json avro decoder: ' + document )
     }
 }

--- a/src/main/groovy/com/vherasymenko/avro/decoder/inbound/MessageListener.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/decoder/inbound/MessageListener.groovy
@@ -1,6 +1,7 @@
 package com.vherasymenko.avro.decoder.inbound
 
 import com.vherasymenko.avro.decoder.core.MessageRouterPort
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cloud.stream.annotation.EnableBinding
 import org.springframework.cloud.stream.annotation.StreamListener
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component
 /**
  * The gateway to the messaging system.
  */
+@Slf4j
 @Component
 @EnableBinding( Sink )
 class MessageListener {
@@ -20,6 +22,7 @@ class MessageListener {
 
     @StreamListener( Sink.INPUT )
     void handleMessage( final Message message ) {
+        log.info( 'The stream listener received a message : ' + message.toString() )
         router.routeEvent( message )
     }
 }

--- a/src/main/groovy/com/vherasymenko/avro/encoder/core/CourseInstallEncoderPort.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/core/CourseInstallEncoderPort.groovy
@@ -3,7 +3,7 @@ package com.vherasymenko.avro.encoder.core
 /**
  * Port to the course install document encoder service.
  */
-interface CourseInstallPort {
+interface CourseInstallEncoderPort {
 
     void handleEvent( String event )
 }

--- a/src/main/groovy/com/vherasymenko/avro/encoder/core/CourseInstallEncoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/core/CourseInstallEncoderService.groovy
@@ -29,6 +29,9 @@ class CourseInstallEncoderService implements CourseInstallEncoderPort {
      */
     private final AvroJsonEncoderPort encoder
 
+    /**
+     * The avro schema registry client.
+     */
     private final SchemaRegistryClient registryClient
 
     CourseInstallEncoderService(MessageProducer aProducer, AvroJsonEncoderPort anEncoder, SchemaRegistryClient aRegistryClient ) {
@@ -83,8 +86,11 @@ class CourseInstallEncoderService implements CourseInstallEncoderPort {
         // encode document using avro json encoding
         def encodedDocument = encoder.encodeEvent( schema, avroData, CourseInstall.class )
 
-        // save schema in the schema registry server
-        def schemaId = registryClient.register( schema.name, 'avro', schema.toString() ).id
+        // save schema to the schema registry server
+        def registryResponse = registryClient.register( schema.name, 'avro', schema.toString() )
+        log.info( "The schema with subject ${registryResponse.schemaReference.subject} was saved to the schema registry " +
+                "with the id ${registryResponse.id}." )
+        def schemaId = registryResponse.id
 
         // send encoded document to the messaging system
         def message = MessageBuilder.withPayload( encodedDocument )

--- a/src/main/groovy/com/vherasymenko/avro/encoder/core/CourseInstallService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/core/CourseInstallService.groovy
@@ -9,11 +9,13 @@ import event.course_install.CourseInstall
 import event.course_install.Lesson
 import event.course_install.Unit
 import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
 import org.springframework.messaging.support.MessageBuilder
 
 /**
  * Service that encodes course install document.
  */
+@Slf4j
 class CourseInstallService implements CourseInstallPort {
 
     /**
@@ -34,6 +36,7 @@ class CourseInstallService implements CourseInstallPort {
     @Override
     void handleEvent( String event ) {
         def schema = CourseInstall.classSchema
+        log.info( 'The avro schema for event encoding : ' + schema.toString( true ) )
 
         def jsonParser = new JsonSlurper()
         def jsonData = jsonParser.parseText( event )

--- a/src/main/groovy/com/vherasymenko/avro/encoder/core/LessonStatusEncoderPort.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/core/LessonStatusEncoderPort.groovy
@@ -3,7 +3,7 @@ package com.vherasymenko.avro.encoder.core
 /**
  * Port to the lesson status document encoder service.
  */
-interface LessonStatusPort {
+interface LessonStatusEncoderPort {
 
     void handleEvent( String event )
 }

--- a/src/main/groovy/com/vherasymenko/avro/encoder/core/LessonStatusEncoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/core/LessonStatusEncoderService.groovy
@@ -16,7 +16,7 @@ import org.springframework.messaging.support.MessageBuilder
  * This service uses nested schemas as well.
  */
 @Slf4j
-class LessonStatusService implements LessonStatusPort {
+class LessonStatusEncoderService implements LessonStatusEncoderPort {
 
     /**
      * The gateway to the messaging system.
@@ -28,7 +28,7 @@ class LessonStatusService implements LessonStatusPort {
      */
     private final AvroBinaryEncoderPort encoder
 
-    LessonStatusService( MessageProducer aProducer, AvroBinaryEncoderPort anEncoder ) {
+    LessonStatusEncoderService(MessageProducer aProducer, AvroBinaryEncoderPort anEncoder ) {
         producer = aProducer
         encoder = anEncoder
     }

--- a/src/main/groovy/com/vherasymenko/avro/encoder/core/LessonStatusEncoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/core/LessonStatusEncoderService.groovy
@@ -9,6 +9,7 @@ import groovy.util.logging.Slf4j
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
 import org.apache.avro.generic.GenericRecord
+import org.springframework.cloud.stream.schema.client.SchemaRegistryClient
 import org.springframework.messaging.support.MessageBuilder
 
 /**
@@ -28,9 +29,16 @@ class LessonStatusEncoderService implements LessonStatusEncoderPort {
      */
     private final AvroBinaryEncoderPort encoder
 
-    LessonStatusEncoderService(MessageProducer aProducer, AvroBinaryEncoderPort anEncoder ) {
+    /**
+     * The avro schema registry client.
+     */
+    private final SchemaRegistryClient registryClient
+
+
+    LessonStatusEncoderService( MessageProducer aProducer, AvroBinaryEncoderPort anEncoder, SchemaRegistryClient aRegistryClient ) {
         producer = aProducer
         encoder = anEncoder
+        registryClient = aRegistryClient
     }
 
     @Override
@@ -69,9 +77,16 @@ class LessonStatusEncoderService implements LessonStatusEncoderPort {
         // encode document using avro binary encoding
         def encodedDocument = encoder.encodeEvent( mainSchema, lessonStatus )
 
+        // save schema to the schema registry server
+        def registryResponse = registryClient.register( mainSchema.name, 'avro', mainSchema.toString() )
+        log.info( "The schema with subject ${registryResponse.schemaReference.subject} was saved to the schema registry " +
+                "with the id ${registryResponse.id}." )
+        def schemaId = registryResponse.id
+
         // send encoded document to the messaging system
         def message = MessageBuilder.withPayload( encodedDocument )
                 .setHeader( MessageHeaders.CONTENT_TYPE, AvroConstants.LESSON_STATUS_CHANNEL )
+                .setHeader( MessageHeaders.SCHEMA_ID, schemaId )
                 .build()
         producer.sendMessage( message )
     }

--- a/src/main/groovy/com/vherasymenko/avro/encoder/core/LessonStatusService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/core/LessonStatusService.groovy
@@ -5,6 +5,7 @@ import com.vherasymenko.avro.encoder.outbound.MessageProducer
 import com.vherasymenko.avro.schared.AvroConstants
 import com.vherasymenko.avro.schared.MessageHeaders
 import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
 import org.apache.avro.generic.GenericRecord
@@ -14,6 +15,7 @@ import org.springframework.messaging.support.MessageBuilder
  * Service that encodes lesson status document. Also uses GenericRecord that works without code generation.
  * This service uses nested schemas as well.
  */
+@Slf4j
 class LessonStatusService implements LessonStatusPort {
 
     /**
@@ -36,6 +38,7 @@ class LessonStatusService implements LessonStatusPort {
         def parser = new Schema.Parser()
         def innerSchema = parser.parse( new File( 'src/main/avro/lessonStatusItem.avsc' ) )
         def mainSchema = parser.parse( new File( 'src/main/avro/lesson_status.avsc' ) )
+        log.info( 'The avro schema for event encoding : ' + mainSchema.toString( true ) )
 
         def jsonParser = new JsonSlurper()
         def jsonData = jsonParser.parseText( event )

--- a/src/main/groovy/com/vherasymenko/avro/encoder/core/binary/AvroBinaryEncoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/core/binary/AvroBinaryEncoderService.groovy
@@ -1,5 +1,6 @@
 package com.vherasymenko.avro.encoder.core.binary
 
+import groovy.util.logging.Slf4j
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericDatumWriter
 import org.apache.avro.generic.GenericRecord
@@ -8,6 +9,7 @@ import org.apache.avro.io.EncoderFactory
 /**
  * The avro binary encoder.
  */
+@Slf4j
 class AvroBinaryEncoderService implements AvroBinaryEncoderPort {
 
     @Override
@@ -19,7 +21,7 @@ class AvroBinaryEncoderService implements AvroBinaryEncoderPort {
 
         def output = new ByteArrayOutputStream()
         def encoder = EncoderFactory.get().binaryEncoder( output, null )
-
+        log.info( 'Avro binary encoding.' )
         datumWriter.write( avroData, encoder )
         encoder.flush()
 

--- a/src/main/groovy/com/vherasymenko/avro/encoder/core/binary/AvroBinaryEncoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/core/binary/AvroBinaryEncoderService.groovy
@@ -20,7 +20,8 @@ class AvroBinaryEncoderService implements AvroBinaryEncoderPort {
         def datumWriter = new GenericDatumWriter( schema )
 
         def output = new ByteArrayOutputStream()
-        def encoder = EncoderFactory.get().binaryEncoder( output, null )
+        def reuse = null // if reuse is provided, it will be reinitialized to the given input stream
+        def encoder = EncoderFactory.get().binaryEncoder( output, reuse )
         log.info( 'Avro binary encoding.' )
         datumWriter.write( avroData, encoder )
         encoder.flush()

--- a/src/main/groovy/com/vherasymenko/avro/encoder/core/json/AvroJsonEncoderService.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/core/json/AvroJsonEncoderService.groovy
@@ -1,5 +1,6 @@
 package com.vherasymenko.avro.encoder.core.json
 
+import groovy.util.logging.Slf4j
 import org.apache.avro.Schema
 import org.apache.avro.io.EncoderFactory
 import org.apache.avro.specific.SpecificDatumWriter
@@ -7,6 +8,7 @@ import org.apache.avro.specific.SpecificDatumWriter
 /**
  * The avro json encoder.
  */
+@Slf4j
 class AvroJsonEncoderService implements AvroJsonEncoderPort {
 
     @Override
@@ -18,7 +20,7 @@ class AvroJsonEncoderService implements AvroJsonEncoderPort {
 
         def output = new ByteArrayOutputStream()
         def encoder = EncoderFactory.get().jsonEncoder( schema, output, true )
-
+        log.info( 'Avro json encoding.' )
         datumWriter.write( avroData, encoder )
         encoder.flush()
 

--- a/src/main/groovy/com/vherasymenko/avro/encoder/inbound/RestGateway.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/inbound/RestGateway.groovy
@@ -1,7 +1,7 @@
 package com.vherasymenko.avro.encoder.inbound
 
-import com.vherasymenko.avro.encoder.core.CourseInstallPort
-import com.vherasymenko.avro.encoder.core.LessonStatusPort
+import com.vherasymenko.avro.encoder.core.CourseInstallEncoderPort
+import com.vherasymenko.avro.encoder.core.LessonStatusEncoderPort
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
@@ -21,15 +21,15 @@ class RestGateway {
     /**
      * The handler for the course install event.
      */
-    private final CourseInstallPort courseInstallEncoder
+    private final CourseInstallEncoderPort courseInstallEncoder
 
     /**
      * The handler for the lesson status event.
      */
-    private final LessonStatusPort lessonInstallEncoder
+    private final LessonStatusEncoderPort lessonInstallEncoder
 
     @Autowired
-    RestGateway(CourseInstallPort aCourseInstallEncoder, LessonStatusPort aLessonInstallEncoder ) {
+    RestGateway(CourseInstallEncoderPort aCourseInstallEncoder, LessonStatusEncoderPort aLessonInstallEncoder ) {
         courseInstallEncoder = aCourseInstallEncoder
         lessonInstallEncoder = aLessonInstallEncoder
     }

--- a/src/main/groovy/com/vherasymenko/avro/encoder/inbound/RestGateway.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/inbound/RestGateway.groovy
@@ -2,6 +2,7 @@ package com.vherasymenko.avro.encoder.inbound
 
 import com.vherasymenko.avro.encoder.core.CourseInstallPort
 import com.vherasymenko.avro.encoder.core.LessonStatusPort
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestBody
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 /**
  * Inbound HTTP gateway.
  */
+@Slf4j
 @RestController
 @RequestMapping( '/' )
 class RestGateway {
@@ -34,12 +36,14 @@ class RestGateway {
 
     @RequestMapping( path = 'course/install', method = [RequestMethod.POST] )
     ResponseEntity<String> serializeCourseInstall( @RequestBody String requestEvent ) {
+        log.info( 'Received POST request to course/install with content: ' + requestEvent )
         courseInstallEncoder.handleEvent( requestEvent )
         ResponseEntity.ok( 'The encoded course install event is sent to the messaging system.' )
     }
 
     @RequestMapping( path = 'lesson/status', method = [RequestMethod.POST] )
     ResponseEntity<String> serializeLessonInstall( @RequestBody String requestEvent ) {
+        log.info( 'Received POST request to status/lesson with content: ' + requestEvent )
         lessonInstallEncoder.handleEvent( requestEvent )
         ResponseEntity.ok( 'The encoded lesson install event is sent to the messaging system.' )
     }

--- a/src/main/groovy/com/vherasymenko/avro/encoder/outbound/MessageProducer.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/encoder/outbound/MessageProducer.groovy
@@ -1,5 +1,6 @@
 package com.vherasymenko.avro.encoder.outbound
 
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cloud.stream.annotation.EnableBinding
 import org.springframework.cloud.stream.messaging.Source
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Component
 /**
  * The gateway to the messaging system.
  */
+@Slf4j
 @Component
 @EnableBinding( Source.class )
 class MessageProducer {
@@ -21,6 +23,7 @@ class MessageProducer {
     }
 
     void sendMessage( Message message ) {
+        log.info( 'Sending message to spring cloud stream.' )
         source.output().send( message )
     }
 }

--- a/src/main/groovy/com/vherasymenko/avro/schared/MessageHeaders.groovy
+++ b/src/main/groovy/com/vherasymenko/avro/schared/MessageHeaders.groovy
@@ -6,4 +6,6 @@ package com.vherasymenko.avro.schared
 class MessageHeaders {
 
     public static final String CONTENT_TYPE = 'Content-Type'
+
+    public static final String SCHEMA_ID = 'Schema-Id'
 }

--- a/src/main/resources/avro/course_install_2.avsc
+++ b/src/main/resources/avro/course_install_2.avsc
@@ -2,7 +2,7 @@
 "namespace": "event.course_install",
 "type": "record",
 "name": "CourseInstall",
-"doc": "The first version of the course install document",
+"doc": "The second version of the course install document",
 "fields": [
         {"name": "course",
          "type": {
@@ -10,7 +10,7 @@
              "name": "Course",
              "fields": [
                 {"name": "uuid", "type": "string"},
-                {"name": "name", "type": "string"},
+                {"name": "courseName", "type": "string", "aliases": ["name"]},
                 {"name": "knownLanguage", "type": "string"},
                 {"name": "targetLanguage", "type": "string"},
                 {"name": "product", "type": "string"}
@@ -24,7 +24,6 @@
                 "type": "record",
                 "name": "Unit",
                 "fields": [
-                    {"name": "id", "type": "int"},
                     {"name": "uuid", "type": "string"},
                     {"name": "name", "type": "string"},
                     {"name": "maxScore", "type": "int"},
@@ -45,7 +44,8 @@
                                 ]
                             }
                         }
-                    }
+                    },
+                    {"name": "newField", "type": "string", "default": "default value for new string"}
                     ]
                 }
             }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -29,6 +29,10 @@ spring:
           password: guest
           virtual-host: /
 
+confluent:
+  schemaregistry:
+    endpoint: http://localhost:8081
+
 management:
     contextPath: /operations
     security:


### PR DESCRIPTION
In this PR I added simple logging.

Also I added integration with the Confluent Schema Registry and tried to encode/decode course_install with different write and read schemas. I tried to remove field and add new one, also rename field, write documentation. If you want to try how it works on your local you should start up Confluent Schema Registry. Use this quickstart: http://docs.confluent.io/3.0.1/quickstart.html . Also you can use this nice schema registry ui: https://hub.docker.com/r/landoop/schema-registry-ui/ to see how schemas are published. 